### PR TITLE
Fix: Implement Dynamic FCU Detection for MAVLink Telemetry

### DIFF
--- a/app/src/main/java/com/example/kotlingcspractice/Telemetry/data.kt
+++ b/app/src/main/java/com/example/kotlingcspractice/Telemetry/data.kt
@@ -3,6 +3,7 @@ package com.example.kotlingcspractice.Telemetry
 data class TelemetryState(
 
     val connected : Boolean = false,
+    val fcuDetected : Boolean = false,
     //Altitude
     val altitudeMsl: Float? = null,
     val altitudeRelative: Float? = null,


### PR DESCRIPTION
The GCS application was previously using hardcoded System and Component IDs (1 and 1) to identify the Flight Control Unit (FCU). This caused the application to fail to fetch telemetry data when connecting to a MAVLink source (like Mission Planner) that used different IDs for the vehicle.

This change refactors the `MavlinkTelemetryRepository` to dynamically discover the FCU's IDs.

Key changes:
- Removed the hardcoded `fcuSystemId` and `fcuComponentId` from the repository.
- Added logic to listen for MAVLink `HEARTBEAT` messages from non-GCS devices.
- The `systemId` and `componentId` from the first received heartbeat are now stored and used as the FCU identifiers.
- Telemetry stream requests (`SET_MESSAGE_INTERVAL`) are now sent only after the FCU has been successfully detected.
- All telemetry data collectors are now filtered to only process messages from the dynamically detected FCU.
- Added an `fcuDetected` flag to the `TelemetryState` to track the detection status.