### PR TITLE
Fix compilation errors in TelemetryRepository

### DIFF
--- a/app/src/main/java/com/example/kotlingcspractice/Telemetry/TelemetryRepository.kt
+++ b/app/src/main/java/com/example/kotlingcspractice/Telemetry/TelemetryRepository.kt
@@ -207,19 +207,11 @@ object MavlinkTelemetryRepository {
         // HEARTBEAT
         scope.launch {
             mavFrameStream
-
-                .filter { frame -> state.value.fcuDetected && frame.systemId == fcuSystemId }
-                .map { frame -> frame.message }
-                .filterIsInstance<Heartbeat>()
-                .collect { hb ->
-                    val armed = hb.baseMode.any { flag -> flag == MavModeFlag.SAFETY_ARMED }
-
                 .filter { state.value.fcuDetected && it.systemId == fcuSystemId }
                 .map { it.message }
                 .filterIsInstance<Heartbeat>()
                 .collect { hb ->
-                    val armed = hb.baseMode.any { it == MavModeFlag.SAFETY_ARMED }
-
+                    val armed = hb.baseMode.any { it == MavModeFlag.SAFETY_ARMED.wrap() }
 
                     // ArduPilot custom modes
                     val mode = when (hb.customMode) {
@@ -250,11 +242,7 @@ object MavlinkTelemetryRepository {
                         27u -> "Auto_RTL"
                         else -> "Unknown"
                     }
-
-                    _state.update { telemetryState -> telemetryState.copy(armed = armed, mode = mode) }
-
                     _state.update { it.copy(armed = armed, mode = mode) }
-
                 }
         }
 
@@ -262,23 +250,17 @@ object MavlinkTelemetryRepository {
         // SYS_STATUS
         scope.launch {
             mavFrameStream
-                .filter { frame -> state.value.fcuDetected && frame.systemId == fcuSystemId }
-                .map { frame -> frame.message }
+                .filter { state.value.fcuDetected && it.systemId == fcuSystemId }
+                .map { it.message }
                 .filterIsInstance<SysStatus>()
                 .collect { s ->
                     val vBatt = if (s.voltageBattery.toUInt() == 0xFFFFu) null else s.voltageBattery.toFloat() / 1000f
                     val pct = if (s.batteryRemaining.toInt() == -1) null else s.batteryRemaining.toInt()
 
-                    val armable = s.onboardControlSensorsPresent.any { sensor -> sensor == MavSysStatus.SENSOR_3D_GYRO } &&
-                            s.onboardControlSensorsEnabled.any { sensor -> sensor == MavSysStatus.SENSOR_3D_GYRO } &&
-                            s.onboardControlSensorsHealth.any { sensor -> sensor == MavSysStatus.SENSOR_3D_GYRO }
-                    _state.update { telemetryState -> telemetryState.copy(voltage = vBatt, batteryPercent = pct, armable = armable) }
-
-                    val armable = s.onboardControlSensorsPresent.any { it == MavSysStatus.SENSOR_3D_GYRO } &&
-                            s.onboardControlSensorsEnabled.any { it == MavSysStatus.SENSOR_3D_GYRO } &&
-                            s.onboardControlSensorsHealth.any { it == MavSysStatus.SENSOR_3D_GYRO }
+                    val armable = s.onboardControlSensorsPresent.any { it == MavSysStatusSensor.SENSOR_3D_GYRO.wrap() } &&
+                            s.onboardControlSensorsEnabled.any { it == MavSysStatusSensor.SENSOR_3D_GYRO.wrap() } &&
+                            s.onboardControlSensorsHealth.any { it == MavSysStatusSensor.SENSOR_3D_GYRO.wrap() }
                     _state.update { it.copy(voltage = vBatt, batteryPercent = pct, armable = armable) }
-
                 }
         }
 


### PR DESCRIPTION
The TelemetryRepository.kt file had several compilation errors due to a recent update in the mavlink-kotlin library. The library now requires enum values to be wrapped using the `.wrap()` method before comparison.

This commit fixes the following issues:
- Adds `.wrap()` to all enum comparisons in the `HEARTBEAT` and `SYS_STATUS` collectors.
- Removes duplicated and commented-out code to improve readability.
- Cleans up the code to follow a consistent style.